### PR TITLE
Remove named parameter duplications on call site in Swift

### DIFF
--- a/Examples/JHChainableAnimations iOS Swift Example/ViewController.swift
+++ b/Examples/JHChainableAnimations iOS Swift Example/ViewController.swift
@@ -66,16 +66,16 @@ class ViewController: UIViewController {
             self.myView.layer.transform = CATransform3DIdentity
             self.myView.frame = CGRect(x: 100, y: 150, width: 50, height: 50)
             self.animator?.transformIdentity.makeOpacity(alpha: 1).makeBackground(color: .blue).animate(t: 1.0)
-            buttonAnimator.moveY(y: -50).easeInOutExpo.animateWithCompletion(t: 1.1, completion: {
+            buttonAnimator.moveY(-50).easeInOutExpo.animate(t: 1.1, completion: {
                 self.button.isUserInteractionEnabled = true
             })
         }
         
-        buttonAnimator.moveY(y: 50).easeInOutExpo.animate(t: 0.5)
+        buttonAnimator.moveY(50).easeInOutExpo.animate(t: 0.5)
         
-        animator.moveWidth(width: 30).bounce.makeBackground(color: .purple).easeIn.anchorTopLeft
+        animator.moveWidth(30).bounce.makeBackground(color: .purple).easeIn.anchorTopLeft
             .repeatAnimation(t: 0.5, count: 3).rotateZ(angle: 95).easeBack.wait(t: 0.2)
-            .thenAfter(t: 0.5).moveY(y: 300).easeIn.makeOpacity(alpha: 0.0).animate(t: 0.4);
+            .thenAfter(t: 0.5).moveY(300).easeIn.makeOpacity(alpha: 0.0).animate(t: 0.4);
         
     }
 }

--- a/Examples/JHChainableAnimations tvOS Swift Example/ViewController.swift
+++ b/Examples/JHChainableAnimations tvOS Swift Example/ViewController.swift
@@ -66,16 +66,16 @@ class ViewController: UIViewController {
             self.myView.layer.transform = CATransform3DIdentity
             self.myView.frame = CGRect(x: 100, y: 150, width: 50, height: 50)
             self.animator?.transformIdentity.makeOpacity(alpha: 1).makeBackground(color: .blue).animate(t: 1.0)
-            buttonAnimator.moveY(y: -50).easeInOutExpo.animateWithCompletion(t: 1.1, completion: {
+            buttonAnimator.moveY(-50).easeInOutExpo.animate(t: 1.1, completion: {
                 self.button.isUserInteractionEnabled = true
             })
         }
         
-        buttonAnimator.moveY(y: 50).easeInOutExpo.animate(t: 0.5)
+        buttonAnimator.moveY(50).easeInOutExpo.animate(t: 0.5)
         
-        animator.moveWidth(width: 30).bounce.makeBackground(color: .purple).easeIn.anchorTopLeft
+        animator.moveWidth(30).bounce.makeBackground(color: .purple).easeIn.anchorTopLeft
             .repeatAnimation(t: 0.5, count: 3).rotateZ(angle: 95).easeBack.wait(t: 0.2)
-            .thenAfter(t: 0.5).moveY(y: 300).easeIn.makeOpacity(alpha: 0.0).animate(t: 0.4);
+            .thenAfter(t: 0.5).moveY(300).easeIn.makeOpacity(alpha: 0.0).animate(t: 0.4);
         
     }
 }

--- a/JHChainableAnimations/ChainableAnimator.swift
+++ b/JHChainableAnimations/ChainableAnimator.swift
@@ -62,12 +62,12 @@ public final class ChainableAnimator {
 
 public extension ChainableAnimator {
     
-    public func makeFrame(frame: CGRect) -> Self {
+    public func makeFrame(_ frame: CGRect) -> Self {
         animator.makeFrame()(frame)
         return self;
     }
     
-    public func makeBounds(bounds: CGRect) -> Self {
+    public func makeBounds(_ bounds: CGRect) -> Self {
         animator.makeBounds()(bounds)
         return self
     }
@@ -87,22 +87,22 @@ public extension ChainableAnimator {
         return self
     }
     
-    public func makeX(x: Float) -> Self {
+    public func makeX(_ x: Float) -> Self {
         animator.makeX()(x.toCG)
         return self
     }
     
-    public func makeY(y: Float) -> Self {
+    public func makeY(_ y: Float) -> Self {
         animator.makeY()(y.toCG)
         return self
     }
     
-    public func makeWidth(width: Float) -> Self {
+    public func makeWidth(_ width: Float) -> Self {
         animator.makeWidth()(width.toCG)
         return self
     }
     
-    public func makeHeight(height: Float) -> Self {
+    public func makeHeight(_ height: Float) -> Self {
         animator.makeHeight()(height.toCG)
         return self
     }
@@ -117,32 +117,32 @@ public extension ChainableAnimator {
         return self
     }
     
-    public func makeBorderColor(color: UIColor) -> Self {
+    public func makeBorderColor(_ color: UIColor) -> Self {
         animator.makeBorderColor()(color)
         return self
     }
     
-    public func makeBorderWidth(width: Float) -> Self {
+    public func makeBorderWidth(_ width: Float) -> Self {
         animator.makeBorderWidth()(width.toCG)
         return self
     }
     
-    public func makeCornerRadius(cornerRadius: Float) -> Self {
+    public func makeCornerRadius(_ cornerRadius: Float) -> Self {
         animator.makeCornerRadius()(cornerRadius.toCG)
         return self
     }
     
-    public func makeScale(scale: Float) -> Self {
+    public func makeScale(_ scale: Float) -> Self {
         animator.makeScale()(scale.toCG)
         return self
     }
     
-    public func makeScaleY(scaleY: Float) -> Self {
+    public func makeScaleY(_ scaleY: Float) -> Self {
         animator.makeScaleY()(scaleY.toCG)
         return self
     }
     
-    public func makeScaleX(scaleX: Float) -> Self {
+    public func makeScaleX(_ scaleX: Float) -> Self {
         animator.makeScaleX()(scaleX.toCG)
         return self
     }
@@ -152,12 +152,12 @@ public extension ChainableAnimator {
         return self
     }
     
-    public func moveX(x: Float) -> Self {
+    public func moveX(_ x: Float) -> Self {
         animator.moveX()(x.toCG)
         return self
     }
     
-    public func moveY(y: Float) -> Self {
+    public func moveY(_ y: Float) -> Self {
         animator.moveY()(y.toCG)
         return self
     }
@@ -167,12 +167,12 @@ public extension ChainableAnimator {
         return self
     }
     
-    public func moveWidth(width: Float) -> Self {
+    public func moveWidth(_ width: Float) -> Self {
         animator.moveWidth()(width.toCG)
         return self
     }
     
-    public func moveHeight(height: Float) -> Self {
+    public func moveHeight(_ height: Float) -> Self {
         animator.moveHeight()(height.toCG)
         return self
     }
@@ -207,12 +207,12 @@ public extension ChainableAnimator {
         return self
     }
     
-    public func transformX(x: Float) -> Self {
+    public func transformX(_ x: Float) -> Self {
         animator.transformX()(x.toCG)
         return self
     }
     
-    public func transformY(x: Float) -> Self {
+    public func transformY(_ x: Float) -> Self {
         animator.transformY()(x.toCG)
         return self
     }
@@ -222,32 +222,32 @@ public extension ChainableAnimator {
         return self
     }
     
-    public func transformScale(scale: Float) -> Self {
+    public func transformScale(_ scale: Float) -> Self {
         animator.transformScale()(scale.toCG)
         return self
     }
     
-    public func transformScaleX(scaleX: Float) -> Self {
+    public func transformScaleX(_ scaleX: Float) -> Self {
         animator.transformScaleX()(scaleX.toCG)
         return self
     }
     
-    public func transformScaleY(scaleY: Float) -> Self {
+    public func transformScaleY(_ scaleY: Float) -> Self {
         animator.transformScaleY()(scaleY.toCG)
         return self
     }
     
-    public func moveOnPath(path: UIBezierPath) -> Self {
+    public func moveOnPath(_ path: UIBezierPath) -> Self {
         animator.moveOnPath()(path)
         return self
     }
     
-    public func moveAndRotateOnPath(path: UIBezierPath) -> Self {
+    public func moveAndRotateOnPath(_ path: UIBezierPath) -> Self {
         animator.moveAndRotateOnPath()(path)
         return self
     }
     
-    public func moveAndReverseRotateOnPath(path: UIBezierPath) -> Self {
+    public func moveAndReverseRotateOnPath(_ path: UIBezierPath) -> Self {
         animator.moveAndReverseRotateOnPath()(path)
         return self
     }
@@ -492,22 +492,22 @@ public extension ChainableAnimator {
         return self
     }
     
-    public func customAnimationFunction(function: @escaping (Double, Double, Double, Double) -> (Double)) -> Self {
+    public func customAnimationFunction(_ function: @escaping (Double, Double, Double, Double) -> (Double)) -> Self {
         animator.customAnimationFunction()(function)
         return self
     }
     
-    public func preAnimationBlock(block: @escaping (Void) -> Void) -> Self {
+    public func preAnimationBlock(_ block: @escaping (Void) -> Void) -> Self {
         animator.preAnimationBlock()(block)
         return self
     }
     
-    public func animationBlock(block: @escaping (Void) -> Void) -> Self {
+    public func animationBlock(_ block: @escaping (Void) -> Void) -> Self {
         animator.animationBlock()(block)
         return self
     }
     
-    public func postAnimationBlock(block: @escaping (Void) -> Void) -> Self {
+    public func postAnimationBlock(_ block: @escaping (Void) -> Void) -> Self {
         animator.postAnimationBlock()(block)
         return self
     }
@@ -526,11 +526,11 @@ public extension ChainableAnimator {
         animator.animate()(t)
     }
     
-    public func animateWithRepeat(t: TimeInterval, count: Int) {
-        animator.animateWithRepeat()(t, count)
+    public func animate(t: TimeInterval, repeatCount: Int) {
+        animator.animateWithRepeat()(t, repeatCount)
     }
     
-    public func animateWithCompletion(t: TimeInterval, completion: @escaping (Void) -> Void) {
+    public func animate(t: TimeInterval, completion: @escaping (Void) -> Void) {
         animator.animateWithCompletion()(t, completion)
     }
 }


### PR DESCRIPTION
When using this library in Swift I saw several things that don't comply with the [Swift API Design Guidelines](https://swift.org/documentation/api-design-guidelines/). The most striking one for me was the duplication of names by using parameter naming everywhere, even when the method name includes it already.

In this PR I took a very conservative approach and tried to change as little as possible but still remove the duplication on the call site. For Objective-C this PR shouldn't have any impact, on Swift side the impact is little.

For example, code **previously looked something like this:** 

```swift
buttonAnimator.moveY(y: -50).easeInOutExpo.animateWithCompletion(t: 1.1, completion: { ... })
```
Note that `moveY(y:)` duplicates the `Y` part and that `animateWithCompletion(t:completion:)` duplicates the `completion` part.

**After my PR** is merged, it will look like this:

```swift
buttonAnimator.moveY(-50).easeInOutExpo.animate(t: 1.1, completion: { ... })
```

This is not only shorter but also closer to the Swift API Design Guidelines.

I suggest that you release a new version with a minor version bump (e.g. 2.1) with these changes. Technically it is a breaking change as existing code is not going to work as is. But Xcode provides auto-fixes for most of them.

---

By the way, please consider making all calls compliant to the Design Guidelines if you ever plan to release a major upgrade. For example the above code actually might look something like the following if it was completely compliant:

```swift
buttonAnimator.move(y: -50).ease(.inOutExpo).animate(duration: 1.1, completion: { ... })
```

I also liked the changes made by @Draveness to make the animations callable directly on a view object like `view.animation.move...`. But that's all completely out of this PRs scope. :)